### PR TITLE
Fix `RemovedInDjango41Warning`

### DIFF
--- a/django_dbconn_retry/__init__.py
+++ b/django_dbconn_retry/__init__.py
@@ -1,4 +1,5 @@
 # -* encoding: utf-8 *-
+import django
 import logging
 
 from django.apps.config import AppConfig
@@ -10,7 +11,9 @@ from typing import Union, Tuple, Callable, List  # noqa. flake8 #118
 
 
 _log = logging.getLogger(__name__)
-default_app_config = 'django_dbconn_retry.DjangoIntegration'
+
+if django.VERSION < (3, 2):
+    default_app_config = 'django_dbconn_retry.DjangoIntegration'
 
 pre_reconnect = Signal()
 post_reconnect = Signal()


### PR DESCRIPTION
Greetings dear fellows.
Thank you for the package!


This PR fixes Django 4.1 deprecation warning:

```
RemovedInDjango41Warning: 'django_dbconn_retry' defines default_app_config = 'django_dbconn_retry.DjangoIntegration'. However, Django's automatic detection did not find this configuration. You should move the default config class to the apps submodule of your application and, if this module defines several config classes, mark the default one with default = True.
```


Best,
Rust