### PR TITLE
Add support for delay and backoff settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,7 @@ Setting                       Description
                              ``DBCONN_RETRY_BACKOFF=3`` and
                              ``MAX_DBCONN_RETRY_TIMES=10``, the final retry
                              would wait on the order of tens of hours.
-                             Choose these settings carefully or implement an
-                             additional maximum delay cap if very long waits
+                             Choose these settings carefully if very long waits
                              are not acceptable for your deployment.
 ===========================  ==================================================
 

--- a/README.rst
+++ b/README.rst
@@ -80,13 +80,25 @@ Setting                       Description
 ``MAX_DBCONN_RETRY_TIMES``   Default: ``1``
                              The max times which django-dbconn-retry will try.
 ``DBCONN_RETRY_DELAY``       Default: ``0``
-                             The initial delay in seconds before the first
-                             retry attempt. Set to ``0`` to retry immediately.
+                             The base delay in seconds before each retry
+                             attempt. Used as the initial delay and, together
+                             with ``DBCONN_RETRY_BACKOFF``, controls the delay
+                             for subsequent retries. Set to ``0`` to retry
+                             immediately.
 ``DBCONN_RETRY_BACKOFF``     Default: ``1``
                              The multiplier applied to the delay after each
                              retry. For example, with ``DBCONN_RETRY_DELAY=1``
                              and ``DBCONN_RETRY_BACKOFF=2``, the delays will
-                             be 1s, 2s, 4s, etc.
+                             be 1s, 2s, 4s, etc. Note that delays grow
+                             exponentially and can become very large for
+                             higher values. For example, with
+                             ``DBCONN_RETRY_DELAY=10``,
+                             ``DBCONN_RETRY_BACKOFF=3`` and
+                             ``MAX_DBCONN_RETRY_TIMES=10``, the final retry
+                             would wait on the order of tens of hours.
+                             Choose these settings carefully or implement an
+                             additional maximum delay cap if very long waits
+                             are not acceptable for your deployment.
 ===========================  ==================================================
 
 

--- a/README.rst
+++ b/README.rst
@@ -77,8 +77,16 @@ You can change the value in your ``settings.py``.
 ===========================  ==================================================
 Setting                       Description
 ===========================  ==================================================
-``MAX_DBCONN_RETRY_TIMES``   Default: `1`
+``MAX_DBCONN_RETRY_TIMES``   Default: ``1``
                              The max times which django-dbconn-retry will try.
+``DBCONN_RETRY_DELAY``       Default: ``0``
+                             The initial delay in seconds before the first
+                             retry attempt. Set to ``0`` to retry immediately.
+``DBCONN_RETRY_BACKOFF``     Default: ``1``
+                             The multiplier applied to the delay after each
+                             retry. For example, with ``DBCONN_RETRY_DELAY=1``
+                             and ``DBCONN_RETRY_BACKOFF=2``, the delays will
+                             be 1s, 2s, 4s, etc.
 ===========================  ==================================================
 
 

--- a/django_dbconn_retry/apps.py
+++ b/django_dbconn_retry/apps.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from django.apps.config import AppConfig
 from django.conf import settings
@@ -36,6 +37,8 @@ for module_name, error_name in database_modules:
 def monkeypatch_django() -> None:
     def ensure_connection_with_retries(self: django_db_base.BaseDatabaseWrapper) -> None:
         self._max_dbconn_retry_times = getattr(settings, "MAX_DBCONN_RETRY_TIMES", 1)
+        self._dbconn_retry_delay = getattr(settings, "DBCONN_RETRY_DELAY", 0)
+        self._dbconn_retry_backoff = getattr(settings, "DBCONN_RETRY_BACKOFF", 1)
 
         if self.connection is not None and hasattr(self.connection, 'closed') and self.connection.closed:
             _log.debug("failed connection detected")
@@ -67,6 +70,15 @@ def monkeypatch_django() -> None:
                             # ensure that we retry the connection. Sometimes .closed isn't set correctly.
                             self.connection = None
                             del self._in_connecting
+
+                            # apply delay with backoff before retry
+                            if self._dbconn_retry_delay > 0:
+                                current_delay = self._dbconn_retry_delay * (
+                                    self._dbconn_retry_backoff ** (self._connection_retries - 1)
+                                )
+                                _log.debug("Waiting %.2f seconds before retry attempt %d",
+                                           current_delay, self._connection_retries)
+                                time.sleep(current_delay)
 
                             # give libraries like 12factor-vault the chance to update the credentials
                             pre_reconnect.send(self.__class__, dbwrapper=self)

--- a/django_dbconn_retry/tests/__init__.py
+++ b/django_dbconn_retry/tests/__init__.py
@@ -131,6 +131,7 @@ class DelayBackoffTests(TestCase):
         """Test that sleep is not called with default settings (delay=0)."""
         self.assertRaises(OperationalError, connection.ensure_connection)
         mock_sleep.assert_not_called()
+        self.assertEqual(connection._connection_retries, 3)
         del connection._connection_retries
 
     @override_settings(MAX_DBCONN_RETRY_TIMES=3, DBCONN_RETRY_DELAY=1.0)
@@ -139,6 +140,29 @@ class DelayBackoffTests(TestCase):
         """Test that delay stays constant with default backoff (backoff=1)."""
         self.assertRaises(OperationalError, connection.ensure_connection)
         # With default backoff=1, all delays should be equal to the base delay
+        self.assertEqual(mock_sleep.call_count, 3)
+        for call in mock_sleep.call_args_list:
+            self.assertEqual(call[0][0], 1.0)
+        del connection._connection_retries
+
+    @override_settings(DBCONN_RETRY_DELAY="invalid")
+    @patch("django_dbconn_retry.apps.time.sleep")
+    def test_invalid_retry_delay(self, mock_sleep: Mock) -> None:
+        """Test that an invalid delay defaults to zero"""
+        self.assertRaises(OperationalError, connection.ensure_connection)
+        mock_sleep.assert_not_called()
+        self.assertEqual(connection._connection_retries, 1)
+        del connection._connection_retries
+
+    @override_settings(
+        MAX_DBCONN_RETRY_TIMES=3,
+        DBCONN_RETRY_DELAY=1.0,
+        DBCONN_RETRY_BACKOFF="invalid",
+    )
+    @patch("django_dbconn_retry.apps.time.sleep")
+    def test_invalid_retry_backoff(self, mock_sleep: Mock) -> None:
+        """Test that an invalid backoff defaults to no backoff"""
+        self.assertRaises(OperationalError, connection.ensure_connection)
         self.assertEqual(mock_sleep.call_count, 3)
         for call in mock_sleep.call_args_list:
             self.assertEqual(call[0][0], 1.0)


### PR DESCRIPTION
This PR adds two new settings, `DBCONN_RETRY_DELAY` and `DBCONN_RETRY_BACKOFF`. These settings allow you to configure dbconn-retry to sleep for some time in between retries -- the DELAY setting specifies a number of seconds to wait and the BACKOFF setting specifies how much the DELAY should multiplicatively increase with each retry. This could help with situations where you have intermittent database availability. Let me know if you think this could be a useful behaviour. Thanks, Shawn