### PR TITLE
Validate max retry times and improve coverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ Setting                       Description
 ===========================  ==================================================
 ``MAX_DBCONN_RETRY_TIMES``   Default: ``1``
                              The max times which django-dbconn-retry will try.
+                             Set to ``0`` to disable retries entirely.
 ``DBCONN_RETRY_DELAY``       Default: ``0``
                              The base delay in seconds before each retry
                              attempt. Used as the initial delay and, together

--- a/README.rst
+++ b/README.rst
@@ -65,15 +65,15 @@ Signal                       Description
                              may be in any state.
 ===========================  ==================================================
 
-Both signals send a parameter ``dbwrapper`` which points to the current instance
-of ``django.db.backends.base.BaseDatabaseWrapper`` which allows the signal
-receiver to act on the database connection.
+Both signals send a parameter ``dbwrapper`` which points to the current
+instance of ``django.db.backends.base.BaseDatabaseWrapper`` which allows the
+signal receiver to act on the database connection.
 
 
 Settings
 --------
-Here’s a list of settings available in django-dbconn-retry and their default values.
-You can change the value in your ``settings.py``.
+Here’s a list of settings available in django-dbconn-retry and their default
+values. You can change the value in your ``settings.py``.
 
 ===========================  ==================================================
 Setting                       Description

--- a/django_dbconn_retry/apps.py
+++ b/django_dbconn_retry/apps.py
@@ -38,6 +38,13 @@ for module_name, error_name in database_modules:
 def monkeypatch_django() -> None:
     def ensure_connection_with_retries(self: django_db_base.BaseDatabaseWrapper) -> None:
         self._max_dbconn_retry_times = getattr(settings, "MAX_DBCONN_RETRY_TIMES", 1)
+        # Validate and normalize max retry times to a non-negative integer
+        if not isinstance(self._max_dbconn_retry_times, int) or self._max_dbconn_retry_times < 0:
+            _log.warning(
+                "Invalid MAX_DBCONN_RETRY_TIMES setting %r; falling back to 1.",
+                self._max_dbconn_retry_times,
+            )
+            self._max_dbconn_retry_times = 1
         self._dbconn_retry_delay = getattr(settings, "DBCONN_RETRY_DELAY", 0)
         # Validate and normalize retry delay to a non-negative number
         if not isinstance(self._dbconn_retry_delay, (int, float)) or self._dbconn_retry_delay < 0:
@@ -70,7 +77,11 @@ def monkeypatch_django() -> None:
                     self.connect()
                 except Exception as e:
                     if isinstance(e, _operror_types):
-                        if (
+                        if self._max_dbconn_retry_times == 0:
+                            _log.info("Not reconnecting; MAX_DBCONN_RETRY_TIMES=0.")
+                            del self._in_connecting
+                            raise
+                        elif (
                                 hasattr(self, "_connection_retries") and
                                 self._connection_retries >= self._max_dbconn_retry_times
                         ):

--- a/django_dbconn_retry/tests/__init__.py
+++ b/django_dbconn_retry/tests/__init__.py
@@ -169,6 +169,40 @@ class DelayBackoffTests(TestCase):
         del connection._connection_retries
 
 
+class MaxRetriesTests(TestCase):
+    """
+    Tests for MAX_DBCONN_RETRY_TIMES validation and the zero-retries case.
+    """
+
+    def setUp(self) -> None:
+        _log.debug("[MaxRetriesTests] patching for setup")
+        self.s_connect = BaseDatabaseWrapper.connect
+        BaseDatabaseWrapper.connect = Mock(side_effect=OperationalError('max retries testing'))
+        BaseDatabaseWrapper.connection = property(lambda x: None, lambda x, y: None)  # type: ignore
+
+    def tearDown(self) -> None:
+        _log.debug("[MaxRetriesTests] restoring")
+        BaseDatabaseWrapper.connect = self.s_connect
+        del BaseDatabaseWrapper.connection
+
+    @override_settings(MAX_DBCONN_RETRY_TIMES=0)
+    def test_zero_disables_retries(self) -> None:
+        pre_cb = Mock(name='pre_reconnect_hook')
+        post_cb = Mock(name='post_reconnect_hook')
+        ddr.pre_reconnect.connect(pre_cb)
+        ddr.post_reconnect.connect(post_cb)
+        self.assertRaises(OperationalError, connection.ensure_connection)
+        BaseDatabaseWrapper.connect.assert_called_once()
+        self.assertFalse(pre_cb.called)
+        self.assertFalse(post_cb.called)
+
+    @override_settings(MAX_DBCONN_RETRY_TIMES="invalid")
+    def test_invalid_max_retry_times(self) -> None:
+        self.assertRaises(OperationalError, connection.ensure_connection)
+        self.assertEqual(connection._connection_retries, 1)
+        del connection._connection_retries
+
+
 class AtomicBlockTests(TransactionTestCase):
     """
     Tests for connection retry behavior inside transaction.atomic() blocks.

--- a/django_dbconn_retry/tests/__init__.py
+++ b/django_dbconn_retry/tests/__init__.py
@@ -59,6 +59,12 @@ class FullErrorTests(TestCase):
         ddr.post_reconnect.connect(cb)
         self.do_assert(cb)
 
+    @override_settings(MAX_DBCONN_RETRY_TIMES=max_dbconn_retry_times)
+    def test_non_operational_error_propagates(self) -> None:
+        BaseDatabaseWrapper.connect = Mock(side_effect=ValueError('not a db error'))
+        self.assertRaises(ValueError, connection.ensure_connection)
+        BaseDatabaseWrapper.connect.assert_called_once()
+
 
 def fix_connection(sender: type, *, dbwrapper: BaseDatabaseWrapper, **kwargs: Any) -> None:
     dbwrapper.connect = dbwrapper.s_connect


### PR DESCRIPTION
Hi again, here are some loose changes which I didn't think fit into my previous PRs. These are not urgent for my use case but I thought you might want to consider them.

This PR:
- Adds validation for the MAX_RETRY_TIMES config parameter to match the validation requested by Copilot for the two new config parameters introduced in #129.
- Allows MAX_RETRY_TIMES to be set to 0 as a simple way to disable retries at a config level. 
- Adds a test for a previously uncovered code path (non-database error handling) which now brings coverage up to 100%.
- Reflows the readme to fix two line-too-long warnings emitted by doc8.

Let me know if these are changes which you might be interested in merging.

Thanks, Shawn